### PR TITLE
feat: Add the release date of the color scheme version 1

### DIFF
--- a/src/pages/color-scheme/index.html
+++ b/src/pages/color-scheme/index.html
@@ -87,7 +87,8 @@
 
             <section id="colorSchemePageDescription" class="section color-scheme-page__description">
                 <p class="color-scheme-page__description__text">
-                    YDITSでは独自のカラースキーム (震度配色)を使用しています。
+                    YDITSでは独自のカラースキーム (震度配色)を使用しています。<br>
+                    2023年3月14日に第1版を公開しました。 
                 </p>
             </section>
 


### PR DESCRIPTION
## Changes

### Features

- #5 
  Adds the initial release date of the YDITS color scheme to its description page to provide historical context for the seismic intensity color scheme.
  Key changes:
    - **Release Information**: Added a sentence stating that the first version of the YDITS color scheme was published on March 14, 2023.
