### PR TITLE
release: Publish v2026.05.07.1

### DIFF
--- a/src/pages/docs/dmdata/index.html
+++ b/src/pages/docs/dmdata/index.html
@@ -47,7 +47,7 @@
     <link rel="stylesheet" href="https://cdn.yoneyo.com/sytles/local-noto-sans-jp.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&display=swap" rel="stylesheet">
     <link rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0&icon_names=close,double_arrow,expand_more,language,menu&display=block">
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0&icon_names=arrow_forward,close,double_arrow,expand_more,language,menu&display=block">
 
     <!-- Styles -->
     <link rel="stylesheet" href="/styles/common.css">
@@ -86,7 +86,7 @@
                 <h2 class="section__title overview__title section__title--bar">Project DM-D.S.S とは</h2>
 
                 <p class="section__content overview__content">
-                    Project DM-D.S.S は、個人によって運営されている、多様な防災気象情報を提供するサービスです。<br>
+                    Project DM-D.S.S は、個人によって運営されている、多様な防災気象情報を提供するAPIサービスです。<br>
                 </p>
 
                 <a href="https://dmdata.jp/" id="officialSiteLink" class="overview__official-site-link">
@@ -169,7 +169,7 @@
                                         Windowsに対応しています。
                                     </p>
 
-                                    <span class="applications-list__copyright">&copy; ingenWorkS</span>
+                                    <span class="applications-list__copyright">© ingen084</span>
                                 </div>
 
                                 <div>
@@ -181,16 +181,16 @@
                         </li>
 
                         <li class="applications__li applications-list__li">
-                            <a href="https://ameuma773.github.io/EarthQuickly/index.html" class="applications-list__a">
+                            <a href="https://earthquickly.com/windows/" class="applications-list__a">
                                 <div class="applications-list__content">
-                                    <h3 class="applications-list__label">EarthQuickly</h3>
+                                    <h3 class="applications-list__label">EarthQuickly for Windows</h3>
 
                                     <p class="applications-list__description">
                                         日本の緊急地震速報、地震情報、津波情報、NIED強震モニタをリアルタイムで確認できます。<br>
                                         Windowsに対応しています。
                                     </p>
 
-                                    <span class="applications-list__copyright">&copy; Ameuma773</span>
+                                    <span class="applications-list__copyright">© Ameuma773</span>
                                 </div>
 
                                 <div>

--- a/src/pages/styles/index.css
+++ b/src/pages/styles/index.css
@@ -186,6 +186,11 @@ header nav>ul>li>a {
     width: fit-content;
 }
 
+.adsense {
+    width: 100%;
+    max-width: 769px;
+}
+
 @media (max-width: 768px) {
     header nav>ul>li>a {
         color: #010101;


### PR DESCRIPTION
## Changes

### Feature

- Update DM-D.S.S documentation links and attribution
  Refreshes the DM-D.S.S documentation page with more accurate service wording, current application links, and corrected copyright attribution.
  Key changes:
    - **Clarify service description**: Updates the DM-D.S.S overview text to describe it specifically as an API service.
    - **Refresh application metadata**: Updates EarthQuickly to use the current Windows page URL and display name.
    - **Correct attribution**: Replaces outdated or entity-escaped copyright labels with current visible attribution text.
    - **Load required icon**: Adds the `arrow_forward` Material Symbol to support the page’s icon usage.

### Fix

- Constrain AdSense layout width
  Adds a dedicated AdSense style rule to make ad containers responsive while preventing them from exceeding the intended content width.
  Key changes:
    - **AdSense Container Width**: Set `.adsense` elements to use the full available width of their parent container.
    - **Maximum Layout Constraint**: Limit `.adsense` width to `769px` to keep ad placement aligned with the page layout.